### PR TITLE
Fix multi-tenant support

### DIFF
--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -6,7 +6,7 @@ local instance = inv.parameters._instance;
 // Prevent creating a non-instantiated instance
 assert instance != 'namespaces' : 'component must be instantiated with a name';
 
-local app = argocd.App(instance, 'default') {
+local app = argocd.App(instance, 'default', base='namespaces') {
   spec+: {
     syncPolicy+: {
       syncOptions+: [


### PR DESCRIPTION
We need to pass the base component name to `argocd.App()` when making an instance-aware component multi-tenant aware.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
